### PR TITLE
Patching the amount of money we pass to Stripe

### DIFF
--- a/app/models/spree/gateway/stripe_gateway.rb
+++ b/app/models/spree/gateway/stripe_gateway.rb
@@ -22,18 +22,22 @@ module Spree
     end
 
     def purchase(money, creditcard, gateway_options)
+      money = localize_money(money, gateway_options)
       provider.purchase(*options_for_purchase_or_auth(money, creditcard, gateway_options))
     end
 
     def authorize(money, creditcard, gateway_options)
+      money = localize_money(money, gateway_options)
       provider.authorize(*options_for_purchase_or_auth(money, creditcard, gateway_options))
     end
 
     def capture(money, response_code, gateway_options)
+      money = localize_money(money, gateway_options)
       provider.capture(money, response_code, gateway_options)
     end
 
     def credit(money, creditcard, response_code, gateway_options)
+      money = localize_money(money, gateway_options)
       provider.refund(money, response_code, {})
     end
 
@@ -73,6 +77,32 @@ module Spree
     end
 
     private
+
+    def non_fractional_currency?(currency)
+      provider_class.currencies_without_fractions.include?(currency.to_s)
+    end
+
+    def localize_money(money, gateway_options)
+      currency = gateway_options[:currency]
+      # We have this hack in place because in `activemerchant` the library
+      # automatically divides the number by 100, therefore we end up charging
+      # the customer much less than what we intened to do
+      # Example: pass 3000JPY, divide by 100, try to charge 30JPY.
+      # This is also detailed in https://github.com/activemerchant/active_merchant/issues/1794
+      # and original issue at: https://github.com/activemerchant/active_merchant/issues/1153
+      # The code that divides by 100 is at: https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateway.rb#L266-L276
+      # (this only affected non-fractional currencies)
+      # Also someone tried to fix this https://github.com/activemerchant/active_merchant/pull/2314
+      # and the conclusion was that there was a need for a major version release
+      # which for Activemerchant hasn't happened in a good few years.
+      # https://github.com/activemerchant/active_merchant/issues/1943 - also
+      # PayPal charge works, but refunds are broken.
+      if non_fractional_currency?(currency)
+        money * 100
+      else
+        money
+      end
+    end
 
     # In this gateway, what we call 'secret_key' is the 'login'
     def options

--- a/spec/models/gateway/stripe_gateway_spec.rb
+++ b/spec/models/gateway/stripe_gateway_spec.rb
@@ -198,4 +198,18 @@ describe Spree::Gateway::StripeGateway do
       expect(provider).to receive(:capture).with(9855,'12345',anything).and_return(success_response)
     end
   end
+
+  describe '#localize_money' do
+    context 'with a currency that does not support cents' do
+      it 'multiplies the value by 100' do
+        expect(subject.send(:localize_money, 1999, {currency: "JPY"})).to eq(199900)
+      end
+    end
+
+    context 'with a currency that does support cents' do
+      it 'does not change the value' do
+        expect(subject.send(:localize_money, 12.34, {currency: "USD"})).to eq(12.34)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is because in Activemerchant we divide the number by 100 trying to
create a fraction
(https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateway.rb#L266-L276).